### PR TITLE
Fix 'int wcscmp(const wchar_t *,const wchar_t *)': cannot convert argument 1 from 'CHAR [260]' to 'const wchar_t *'

### DIFF
--- a/apc-ppid.cpp
+++ b/apc-ppid.cpp
@@ -4,15 +4,15 @@
 
 DWORD getParentProcessID() {
 	HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-	PROCESSENTRY32 process = { 0 };
+	PROCESSENTRY32W process = { 0 };
 	process.dwSize = sizeof(process);
 
-	if (Process32First(snapshot, &process)) {
+	if (Process32FirstW(snapshot, &process)) {
 		do {
             		//If you want to another process as parent change here
 			if (!wcscmp(process.szExeFile, L"explorer.exe"))
 				break;
-		} while (Process32Next(snapshot, &process));
+		} while (Process32NextW(snapshot, &process));
 	}
 
 	CloseHandle(snapshot);


### PR DESCRIPTION
Does not need `/D UNICEODE` during compilation now.Just need `cl /EHsc apc-ppid.cpp`